### PR TITLE
fix: fix parsing error on request core when curl session failed

### DIFF
--- a/src/Requests/RequestCore.php
+++ b/src/Requests/RequestCore.php
@@ -661,7 +661,7 @@ class RequestCore
         $this->response = curl_exec($curl_handle);
 
         if ($this->response === false) {
-            throw new Exception('[RequestCoreException] cURL resource: ' . (string) $curl_handle . '; cURL error: ' . curl_error($curl_handle) . ' (' . curl_errno($curl_handle) . ')');
+            throw new Exception('[RequestCoreException] cURL error: ' . curl_error($curl_handle) . ' (' . curl_errno($curl_handle) . ')');
         }
 
         $parsed_response = $this->process_response($curl_handle, $this->response);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Aliyun\SLS\Requests\RequestCore;
+
+
+/**
+ * @author Adi Putra <adiputrapermana@gmail.com>
+ */
+class RequestTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @throws \Aliyun\SLS\Exception
+     */
+    public function testFailedRequest()
+    {
+        $request = new RequestCore('https://unreachable-api.com');
+        $request->set_curlopts([CURLOPT_TIMEOUT => 1]);
+
+        $this->setExpectedException(\Aliyun\SLS\Exception::class);
+        $request->send_request();
+    }
+}


### PR DESCRIPTION
### Fixed

- Failed to parse CurlHandle object to string on PHP 8